### PR TITLE
Bugfix/survey lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ yarn-error.log*
 # misc
 .DS_Store
 
+# mongo
+dump/

--- a/src/components/elements/SurveyListing/index.tsx
+++ b/src/components/elements/SurveyListing/index.tsx
@@ -16,8 +16,8 @@ export const SurveyListing: React.FC<Props> = ({ backgroundColor, survey }) => {
     <LinkBox
       bgColor={backgroundColor}
       _hover={{ bgColor: 'brand.100' }}
-      w={'100%'}
-      h='75'
+      w='100%'
+      h={75}
       pt={1}
       px={APP_PADDING.px}
     >

--- a/src/queries/survey/getSurveyByIdQuery.ts
+++ b/src/queries/survey/getSurveyByIdQuery.ts
@@ -43,6 +43,7 @@ export function getSurveyByIdQuery({
 
       return null
     },
+    refetchOnMount: 'always',
     onError: () => {
       throw GenericStatusError({ status: 501, message: 'An unknown error has occurred' })
     },

--- a/src/queries/survey/getTodaysSurveyQueryId.ts
+++ b/src/queries/survey/getTodaysSurveyQueryId.ts
@@ -19,6 +19,7 @@ export function getTodaysSurveyIdQuery(): UseQueryResult<{ id: string | undefine
       const json = res.json()
       return json
     },
+    refetchOnMount: 'always',
     retry: (failCount, error: GenericStatusErrorType) => {
       console.error({ error })
       return failCount < 3

--- a/src/queries/survey/getUsersSurveysQuery.ts
+++ b/src/queries/survey/getUsersSurveysQuery.ts
@@ -27,6 +27,7 @@ export function getUsersSurveysQuery({
       const json = await res.json()
       return json
     },
+    refetchOnMount: 'always',
     retry: (failCount, error: GenericStatusErrorType) => {
       console.error({ error })
       return failCount < 3

--- a/src/queries/survey/getUsersTotalScoreQuery.ts
+++ b/src/queries/survey/getUsersTotalScoreQuery.ts
@@ -17,6 +17,7 @@ export function getUsersTotalScoreQuery(): UseQueryResult<{ totalScore: number }
       const json = await res.json()
       return json
     },
+    refetchOnMount: 'always',
     retry: (failCount, error: GenericStatusErrorType) => {
       console.error({ error })
       return failCount < 3

--- a/src/views/Authenticated/Calendar/index.tsx
+++ b/src/views/Authenticated/Calendar/index.tsx
@@ -22,9 +22,7 @@ const Calendar: React.FC = () => {
   const [todaysScore, setTodaysScore] = React.useState<number>(0)
 
   React.useEffect(() => {
-    if (todaysSurveyIdIsLoaded && !!todaysSurveyId.id) {
-      setTodaysScore(0)
-    } else if (todaysSurveyIdIsLoaded && todaysSurveyLoaded && todaysSurvey) {
+    if (todaysSurveyIdIsLoaded && todaysSurveyLoaded && todaysSurvey) {
       setTodaysScore(todaysSurvey.pointsEarned || 0)
     }
   }, [todaysSurveyId, todaysSurveyIdIsLoaded, todaysSurveyLoaded, todaysSurvey])
@@ -64,15 +62,15 @@ const Calendar: React.FC = () => {
           </Stack>
           {surveyDataIsLoaded ? (
             userSurveyData &&
+            userSurveyData.docs &&
             userSurveyData.docs.length > 0 &&
             userSurveyData.docs.map((survey, index) => (
-              <>
+              <React.Fragment key={survey.id}>
                 <SurveyListing
                   backgroundColor={index % 2 === 0 ? 'white' : 'gray.100'}
                   survey={survey}
-                  key={survey.id}
                 />
-              </>
+              </React.Fragment>
             ))
           ) : (
             <>


### PR DESCRIPTION
Added some "refetch on mount" configurations to the fetch for todays surveys, this fixed the bug that made the UI think the survey the user just started was outdated and therefore locked it.